### PR TITLE
Adds user agent to fetch calls

### DIFF
--- a/src/util/zip.ts
+++ b/src/util/zip.ts
@@ -40,6 +40,7 @@ export async function fetchHttp(url: string): Promise<Buffer> {
   const response = await axios
     .get(url, {
       responseType: "arraybuffer",
+      headers: { "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36 Edg/96.0.1054.57 PWABuilderHttpAgent" }
     })
     .catch((err) => {
       throw err;


### PR DESCRIPTION
This aides in getting on Cloudflare's whitelist, which will prevent numerous issues around PWABuilder being blocked.